### PR TITLE
Normalize stored HTML entities to avoid double-encoding

### DIFF
--- a/src/forms/filters.php
+++ b/src/forms/filters.php
@@ -9,7 +9,7 @@
 						    <!-- SEARCH -->
 							<div class="col-5 col-md-2">
 								<div class="input-group">
-									<input type="text" class="form-control" placeholder="Search" id="input_search" name="search_str" value="<?php echo htmlspecialchars($search_str??'', ENT_QUOTES, 'UTF-8'); ?>">
+                                                                     <input type="text" class="form-control" placeholder="Search" id="input_search" name="search_str" value="<?php echo escape_output($search_str??''); ?>">
 									<div class="input-group-append">
 										<span class="input-group-text">
 											<i class="fas fa-search"></i>

--- a/src/forms/form_dynamic_edit.php
+++ b/src/forms/form_dynamic_edit.php
@@ -2,7 +2,7 @@
     <div class="col-sm-4">
         <div class="form-group">
             <label for="identifier">Redirect identifier</label>
-            <input type="text" name="identifier" value="<?php echo htmlspecialchars($edit ? $dynamic_qrcode['identifier'] : '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Identifier" class="form-control" id="identifier" readonly>
+            <input type="text" name="identifier" value="<?php echo escape_output($edit ? $dynamic_qrcode['identifier'] : ''); ?>" placeholder="Identifier" class="form-control" id="identifier" readonly>
         </div>
     </div>
     
@@ -11,14 +11,14 @@
         <div class="form-group">
             <label for="filename">Filename *</label>
             <p>N.B. You can change the name of the file visible in the table, however a new qr code will NOT be generated</p>
-            <input type="text" name="filename" value="<?php echo htmlspecialchars($edit ? $dynamic_qrcode['filename'] : '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Filename" class="form-control" required="required" id = "filename">
+            <input type="text" name="filename" value="<?php echo escape_output($edit ? $dynamic_qrcode['filename'] : ''); ?>" placeholder="Filename" class="form-control" required="required" id = "filename">
         </div> 
     </div>
     
     <div class="col-sm-4">
         <div class="form-group">
             <label for="link">URL *</label>
-            <input type="url" pattern="https?://.*" name="link" value="<?php echo htmlspecialchars($edit ? $dynamic_qrcode['link'] : '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Link" class="form-control" required="required" id="link">
+            <input type="url" pattern="https?://.*" name="link" value="<?php echo escape_output($edit ? $dynamic_qrcode['link'] : ''); ?>" placeholder="Link" class="form-control" required="required" id="link">
         </div>
     </div>
     

--- a/src/forms/form_static_edit.php
+++ b/src/forms/form_static_edit.php
@@ -4,7 +4,7 @@
         <div class="form-group">
             <label for="filename">Filename *</label>
             <p>N.B. You can change the name of the file visible in the table, however a new qr code will NOT be generated</p>
-            <input type="text" name="filename" value="<?php echo htmlspecialchars($edit ? $static_qrcode['filename'] : '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Filename" class="form-control" required="required" id = "filename">
+            <input type="text" name="filename" value="<?php echo escape_output($edit ? $static_qrcode['filename'] : ''); ?>" placeholder="Filename" class="form-control" required="required" id = "filename">
         </div> 
     </div>
 

--- a/src/forms/table_dynamic.php
+++ b/src/forms/table_dynamic.php
@@ -58,14 +58,14 @@
                     }
                     ?>
                 </td>
-                <td><?php echo htmlspecialchars($row['filename']); ?></td>
-                <td><?php echo htmlspecialchars($row['identifier']); ?></td>
-                <td><?php echo htmlspecialchars($row['link']); ?></td>
+                <td><?php echo escape_output($row['filename']); ?></td>
+                <td><?php echo escape_output($row['identifier']); ?></td>
+                <td><?php echo escape_output($row['link']); ?></td>
                 <td>
-                    <?php echo '<img src="'.SAVED_QRCODE_FOLDER.htmlspecialchars($row['qrcode']).'" width="100" height="100">'; ?>
+                    <?php echo '<img src="'.SAVED_QRCODE_FOLDER.escape_output($row['qrcode']).'" width="100" height="100">'; ?>
                 </td>
-                <td><?php echo htmlspecialchars($row['scan']); ?></td>
-                <td><?php echo htmlspecialchars($row['state']); ?></td>
+                <td><?php echo escape_output($row['scan']); ?></td>
+                <td><?php echo escape_output($row['state']); ?></td>
                 <td>
                     
                     <!-- EDIT -->
@@ -80,7 +80,7 @@
                     ><i class="fas fa-trash"></i></a>
                     
                     <!-- DOWNLOAD -->
-                    <a href="<?php echo SAVED_QRCODE_FOLDER.htmlspecialchars($row['qrcode']); ?>" class="btn btn-primary" download><i class="fa fa-download"></i></a>
+                    <a href="<?php echo SAVED_QRCODE_FOLDER.escape_output($row['qrcode']); ?>" class="btn btn-primary" download><i class="fa fa-download"></i></a>
                 </td>
             </tr>
             <?php endforeach; ?>

--- a/src/forms/table_static.php
+++ b/src/forms/table_static.php
@@ -56,11 +56,11 @@
                     }
                     ?>
                 </td>
-                <td><?php echo htmlspecialchars($row['filename']); ?></td>
-                <td><?php echo htmlspecialchars($row['type']); ?></td>
+                <td><?php echo escape_output($row['filename']); ?></td>
+                <td><?php echo escape_output($row['type']); ?></td>
                 <td><?php echo htmlspecialchars_decode($row['content']); ?></td>
                 <td>
-                    <?php echo '<img src="'.SAVED_QRCODE_FOLDER.htmlspecialchars($row['qrcode']).'" width="100" height="100">'; ?>
+                    <?php echo '<img src="'.SAVED_QRCODE_FOLDER.escape_output($row['qrcode']).'" width="100" height="100">'; ?>
                 </td>
                 <td>
                     
@@ -76,7 +76,7 @@
                     ><i class="fas fa-trash"></i></a>
 
                     <!-- DOWNLOAD -->
-                    <a href="<?php echo SAVED_QRCODE_FOLDER.htmlspecialchars($row['qrcode']); ?>" class="btn btn-primary" download><i class="fa fa-download"></i></a>
+                    <a href="<?php echo SAVED_QRCODE_FOLDER.escape_output($row['qrcode']); ?>" class="btn btn-primary" download><i class="fa fa-download"></i></a>
                 </td>
             </tr>
             <?php endforeach; ?>

--- a/src/forms/table_users.php
+++ b/src/forms/table_users.php
@@ -15,8 +15,8 @@
             <?php foreach ($rows as $row): ?>
             <tr>
                 <td><?php echo $row['id']; ?></td>
-                <td><?php echo htmlspecialchars($row['username']); ?></td>
-                <td><?php echo htmlspecialchars($row['type']); ?></td>
+                <td><?php echo escape_output($row['username']); ?></td>
+                <td><?php echo escape_output($row['type']); ?></td>
                 <td>
                     <!-- EDIT -->
                     <a href="user.php?edit=true&id=<?php echo $row['id']; ?>" class="btn btn-primary"><i class="fas fa-edit"></i></a>

--- a/src/helpers/helpers.php
+++ b/src/helpers/helpers.php
@@ -48,10 +48,44 @@ function clearAuthCookie() {
  *
  */
 function clean_input($data) {
-	$data = trim($data);
-	$data = stripslashes($data);
-	$data = htmlspecialchars($data);
-	return $data;
+        $data = trim($data);
+        $data = stripslashes($data);
+        $data = htmlspecialchars($data);
+        return $data;
+}
+
+/**
+ * Decode HTML special characters that may have been encoded multiple times.
+ *
+ * Older versions of the application stored values using htmlspecialchars() and
+ * that resulted in data being persisted as "&amp;". When those values were
+ * rendered again they were encoded repeatedly ("&amp;amp;" and so on).  This
+ * helper normalises the stored value by decoding the HTML entities until the
+ * string no longer changes, effectively giving us the original raw value.
+ */
+function normalize_html_entities($value, int $flags = ENT_QUOTES): string {
+        $normalized = (string)($value ?? '');
+
+        do {
+                $previous = $normalized;
+                $normalized = htmlspecialchars_decode($previous, $flags);
+        } while ($normalized !== $previous);
+
+        return $normalized;
+}
+
+/**
+ * Escape a value for safe output in HTML contexts.
+ *
+ * It first normalises the stored value (see normalize_html_entities()) and then
+ * applies htmlspecialchars() so that we never double-encode ampersands or
+ * other entities when rendering database values inside HTML attributes or
+ * plain text.
+ */
+function escape_output($value, int $flags = ENT_QUOTES): string {
+        $normalized = normalize_html_entities($value, $flags);
+
+        return htmlspecialchars($normalized, $flags, 'UTF-8');
 }
 
 function paginationLinks($current_page, $total_pages, $base_url) {

--- a/src/lib/DynamicQrcode/DynamicQrcode.php
+++ b/src/lib/DynamicQrcode/DynamicQrcode.php
@@ -61,9 +61,9 @@ class DynamicQrcode {
         else
             $data_to_db['id_owner'] = NULL;
 
-        $data_to_db['filename'] = htmlspecialchars($input_data['filename'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['filename'] = trim(normalize_html_entities($input_data['filename']));
         $data_to_db['created_at'] = date('Y-m-d H:i:s');
-        $data_to_db['link'] = htmlspecialchars($input_data['link'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['link'] = trim(normalize_html_entities($input_data['link']));
         $data_to_db['created_by'] = $_SESSION['user_id'];
         $data_to_db['format'] = $input_data['format'];
         $data_to_db['identifier'] = randomString(rand(5,8));
@@ -83,9 +83,9 @@ class DynamicQrcode {
             $data_to_db['id_owner'] = $input_data['id_owner'];
         else
             $data_to_db['id_owner'] = NULL;
-        $data_to_db['filename'] = htmlspecialchars($input_data['filename'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['filename'] = trim(normalize_html_entities($input_data['filename']));
         $data_to_db['created_at'] = date('Y-m-d H:i:s');
-        $data_to_db['link'] = htmlspecialchars($input_data['link'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['link'] = trim(normalize_html_entities($input_data['link']));
         $data_to_db['state'] = $input_data['state'];
 
         $this->qrcode_instance->editQrcode($input_data, $data_to_db);

--- a/src/lib/StaticQrcode/StaticQrcode.php
+++ b/src/lib/StaticQrcode/StaticQrcode.php
@@ -395,7 +395,7 @@ class StaticQrcode {
             $data_to_db['id_owner'] = NULL;
         $data_to_db['created_at'] = date('Y-m-d H:i:s');
         $data_to_db['created_by'] = $_SESSION['user_id'];
-        $data_to_db['filename'] = htmlspecialchars($_POST['filename'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['filename'] = trim(normalize_html_entities($_POST['filename']));
         $data_to_db['created_at'] = date('Y-m-d H:i:s');
         $data_to_db['type'] = $type;
         $data_to_db['format'] = $_POST['format'];
@@ -425,7 +425,7 @@ class StaticQrcode {
             $data_to_db['id_owner'] = $input_data['id_owner'];
         else
             $data_to_db['id_owner'] = NULL;
-        $data_to_db['filename'] = htmlspecialchars($input_data['filename'], ENT_QUOTES, 'UTF-8');
+        $data_to_db['filename'] = trim(normalize_html_entities($input_data['filename']));
         $data_to_db['created_at'] = date('Y-m-d H:i:s');
 
         $this->qrcode_instance->editQrcode($input_data, $data_to_db);

--- a/src/read.php
+++ b/src/read.php
@@ -34,9 +34,10 @@ if (!$db->update('dynamic_qrcodes', $data)) {
 
 if ($qrcode['state'] == 'enable') {
     // Validation and escaping of the URL to avoid XSS attacks
-    $link = filter_var($qrcode['link'], FILTER_VALIDATE_URL);
+    $link = normalize_html_entities($qrcode['link']);
+    $link = filter_var($link, FILTER_VALIDATE_URL);
     if ($link) {
-        echo '<meta http-equiv="refresh" content="0; URL=' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '" />';
+        echo '<meta http-equiv="refresh" content="0; URL=' . escape_output($link) . '" />';
         echo 'Loading...'; // You can include a custom page to display during the redirect
     } else {
         echo 'Invalid URL';


### PR DESCRIPTION
## Summary
- add helper utilities to normalise stored HTML entities and provide consistent escaping for UI output
- update dynamic and static QR code persistence to strip legacy encoded entities before saving, preventing repeated encoding of ampersands
- use the new escaping helper across tables/forms and the redirect endpoint so existing data renders and redirects with correct URLs

## Testing
- php -l src/helpers/helpers.php
- php -l src/lib/DynamicQrcode/DynamicQrcode.php
- php -l src/lib/StaticQrcode/StaticQrcode.php
- php -l src/forms/form_dynamic_edit.php
- php -l src/forms/form_static_edit.php
- php -l src/forms/table_dynamic.php
- php -l src/forms/table_static.php
- php -l src/forms/table_users.php
- php -l src/forms/filters.php
- php -l src/read.php

------
https://chatgpt.com/codex/tasks/task_e_68d5a4e00a888332bce82e00c278de93